### PR TITLE
Adds H2 webconsole at endpoint /db

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 1. Clone this repository
 2. Go to the root folder of the project
 3. Run `./mwnw spring-boot:run`
+4. H2 webconsole is reachable from http://localhost:8080/db
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+spring.h2.console.enabled=true
+spring.h2.console.path=/db
+spring.h2.console.settings.web-allow-others=true
+spring.h2.console.settings.trace=false
+spring.data.jpa.repositories.enabled=true
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jta.enabled=true
+server.contextPath=/
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+


### PR DESCRIPTION
I thought it might be a good addition to enable the H2 web console for viewing the contents of the database between steps.